### PR TITLE
Simplify the host id command timeout to a single bounded wait

### DIFF
--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResource.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
@@ -262,6 +263,9 @@ public final class HostIdResource {
   // Visible for testing
   static List<String> runCommand(List<String> command, long timeoutMillis) {
     Process process = null;
+    // set once this method stops caring about the result, so that the thread below can tell a
+    // command that failed on its own from one that was killed on the way out
+    AtomicBoolean abandoned = new AtomicBoolean();
     try {
       ProcessBuilder processBuilder = new ProcessBuilder(command);
       processBuilder.redirectErrorStream(true);
@@ -276,7 +280,7 @@ public final class HostIdResource {
       // buffer.
       Process startedProcess = process;
       FutureTask<List<String>> commandOutput =
-          new FutureTask<>(() -> getCommandOutput(startedProcess, command));
+          new FutureTask<>(() -> getCommandOutput(startedProcess, command, abandoned));
       Thread readerThread = new Thread(commandOutput, "otel-host-id-lookup");
       readerThread.setDaemon(true);
       readerThread.start();
@@ -293,6 +297,7 @@ public final class HostIdResource {
       logger.log(FINE, "Interrupted running command " + command, e);
       return emptyList();
     } finally {
+      abandoned.set(true);
       if (process != null) {
         // no-op if the process already exited, otherwise this both stops the stray child and
         // unblocks the reader thread
@@ -301,11 +306,23 @@ public final class HostIdResource {
     }
   }
 
-  private static List<String> getCommandOutput(Process process, List<String> command)
+  private static List<String> getCommandOutput(
+      Process process, List<String> command, AtomicBoolean abandoned)
       throws IOException, InterruptedException {
     List<String> output = getProcessOutput(process.getInputStream());
 
     int exitedValue = process.waitFor();
+    if (abandoned.get()) {
+      // the timeout has already been reported, but whatever the command managed to print before it
+      // was killed is the most useful clue about where it got stuck
+      if (!output.isEmpty()) {
+        logger.fine(
+            "Output of command " + command + " before it was killed: " + String.join("\n", output));
+      }
+
+      return emptyList();
+    }
+
     if (exitedValue != 0) {
       logger.fine(
           "Failed to run command "

--- a/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResource.java
+++ b/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/HostIdResource.java
@@ -9,7 +9,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.logging.Level.FINE;
 
 import io.opentelemetry.api.common.AttributeKey;
@@ -271,36 +270,22 @@ public final class HostIdResource {
       // for input sees EOF and exits instead of running until the timeout
       process.getOutputStream().close();
 
-      long deadlineNanos = System.nanoTime() + MILLISECONDS.toNanos(timeoutMillis);
-      // the output has to be drained on another thread: reading to EOF on this thread is unbounded,
-      // and not draining at all lets a chatty command deadlock on a full pipe buffer
-      InputStream processOutput = process.getInputStream();
-      FutureTask<List<String>> readOutput = new FutureTask<>(() -> getProcessOutput(processOutput));
-      Thread readerThread = new Thread(readOutput, "otel-host-id-lookup");
+      // reading the output to EOF and waiting for the process to exit are both unbounded, so they
+      // run on another thread that the timeout below can walk away from. draining the output also
+      // has to happen before waiting for exit, otherwise a chatty command deadlocks on a full pipe
+      // buffer.
+      Process startedProcess = process;
+      FutureTask<List<String>> commandOutput =
+          new FutureTask<>(() -> getCommandOutput(startedProcess, command));
+      Thread readerThread = new Thread(commandOutput, "otel-host-id-lookup");
       readerThread.setDaemon(true);
       readerThread.start();
 
-      List<String> output = readOutput.get(timeoutMillis, MILLISECONDS);
-      if (!process.waitFor(remainingMillis(deadlineNanos), MILLISECONDS)) {
-        logger.log(FINE, "Timed out running command {0}", command);
-        return emptyList();
-      }
-
-      int exitedValue = process.exitValue();
-      if (exitedValue != 0) {
-        logger.fine(
-            "Failed to run command "
-                + command
-                + ". Exit code: "
-                + exitedValue
-                + " Output: "
-                + String.join("\n", output));
-
-        return emptyList();
-      }
-
-      return output;
-    } catch (IOException | ExecutionException | TimeoutException e) {
+      return commandOutput.get(timeoutMillis, MILLISECONDS);
+    } catch (TimeoutException e) {
+      logger.log(FINE, "Timed out running command {0}", command);
+      return emptyList();
+    } catch (IOException | ExecutionException e) {
       logger.log(FINE, "Failed to run command " + command, e);
       return emptyList();
     } catch (InterruptedException e) {
@@ -316,8 +301,24 @@ public final class HostIdResource {
     }
   }
 
-  private static long remainingMillis(long deadlineNanos) {
-    return Math.max(0, NANOSECONDS.toMillis(deadlineNanos - System.nanoTime()));
+  private static List<String> getCommandOutput(Process process, List<String> command)
+      throws IOException, InterruptedException {
+    List<String> output = getProcessOutput(process.getInputStream());
+
+    int exitedValue = process.waitFor();
+    if (exitedValue != 0) {
+      logger.fine(
+          "Failed to run command "
+              + command
+              + ". Exit code: "
+              + exitedValue
+              + " Output: "
+              + String.join("\n", output));
+
+      return emptyList();
+    }
+
+    return output;
   }
 
   private static List<String> getProcessOutput(InputStream processOutput) throws IOException {


### PR DESCRIPTION
AI-generated suggestion for #19377, not urgent -- feel free to close if you disagree.

Reading the output to EOF and waiting for the process to exit are both unbounded, but only the read was moved off the calling thread. That's what forces the second bounded wait, and with it the shared deadline and `remainingMillis`. Running both on the reader thread leaves a single bounded wait.

Everything else is unchanged: the calling thread still owns the `Process`, so `finally` can always kill it; the thread is still only created after `start()` succeeds; and closing stdin still applies. Existing tests pass unmodified.

I also don't think the `waitFor(remainingMillis(...))` branch is reachable in practice. Since `redirectErrorStream(true)` puts stderr on the same pipe, EOF only arrives once the child has closed both streams, which realistically means it exited -- so in a real hang the read times out first and `Timed out running command {0}` never fires.

The second commit deals with something the refactor exposes: with the exit-code check on the reader thread, `destroyForcibly` unblocks that thread on timeout and it reports the command as having failed on its own, on top of the timeout already logged. It now tells those apart, and for a killed command logs what it printed before the kill, which today is discarded:

```
Timed out running command [/usr/sbin/ioreg, -rd1, -c, IOPlatformExpertDevice]
Output of command [/usr/sbin/ioreg, -rd1, -c, IOPlatformExpertDevice] before it was killed: ...
```